### PR TITLE
Correct path reference to react-templates API

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 // through2 is a thin wrapper around node transform streams
 var through = require('through2');
 var gutil = require('gulp-util');
-var rt = require('react-templates');
+var rt = require('react-templates/src/reactTemplates');
 var PluginError = gutil.PluginError;
 //var applySourceMap = require('vinyl-sourcemaps-apply');
 var path = require('path');

--- a/test/main.js
+++ b/test/main.js
@@ -1,7 +1,7 @@
 'use strict';
 var rt = require('../');
 var should = require('should');
-var reactTemplates = require('react-templates');
+var reactTemplates = require('react-templates/src/reactTemplates');
 var gutil = require('gulp-util');
 //var fs = require('fs');
 var path = require('path');


### PR DESCRIPTION
`react-templates` has a 'main' reference of `src/cli.js`, which doesn't
help with programmatic access to react-templates. Change the reference
to `src/reactTemplates`, which has the desired exports.

Without this, the plugin fails with the error `TypeError: Object #<Object> has no method 'convertTemplateToReact'`
