### PR TITLE
Module noun fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,10 @@ var merge = require('merge');
 // Consts
 var PLUGIN_NAME = 'gulp-react-templates';
 
+function normalizeName(name) {
+    return name.replace(/-/g, '_');
+}
+
 module.exports = function (opt) {
     function replaceExtension(filePath) {
         return filePath + '.js';
@@ -23,9 +27,8 @@ module.exports = function (opt) {
             return cb(new PluginError(PLUGIN_NAME, 'Streaming not supported'));
         }
 
-        //console.log('rt ' + file.path);
-
         var data;
+        var filePath = file.path;
         var str = file.contents.toString('utf8');
         var dest = replaceExtension(file.path);
 
@@ -34,6 +37,11 @@ module.exports = function (opt) {
             sourceFiles: [file.relative],
             generatedFile: replaceExtension(file.relative)
         }, opt);
+
+        var shouldAddName = options.modules === 'none' && !options.name;
+        if (shouldAddName) {
+            options.name = normalizeName(path.basename(filePath, path.extname(filePath))) + 'RT';
+        }
 
         try {
             data = rt.convertTemplateToReact(str, options);

--- a/test/fixtures/b.rt
+++ b/test/fixtures/b.rt
@@ -1,0 +1,1 @@
+<div>Hello</div>

--- a/test/fixtures/b.rt.js
+++ b/test/fixtures/b.rt.js
@@ -1,0 +1,3 @@
+var bRT = function () {
+    return React.createElement('div', {}, 'Hello');
+};

--- a/test/main.js
+++ b/test/main.js
@@ -88,5 +88,17 @@ describe('gulp-react-templates', function () {
                 })
                 .write(createFile(filepath, contents));
         });
+
+        it('should correctly handle modules:none', function (done) {
+            var filepath = path.resolve(__dirname, '../fixtures/b.rt');
+            var contents = new Buffer('<div>Hello</div>');
+            var opts = {modules: 'none'};
+            var expected = reactTemplates.convertTemplateToReact(String(contents), opts);
+
+            rt(opts)
+                .on('error', done)
+                .on('data', this.testData(expected, path.resolve(__dirname, '../fixtures/b.rt.js'), done))
+                .write(createFile(filepath, contents));
+        });
     });
 });

--- a/test/main.js
+++ b/test/main.js
@@ -3,10 +3,8 @@ var rt = require('../');
 var should = require('should');
 var reactTemplates = require('react-templates');
 var gutil = require('gulp-util');
-//var fs = require('fs');
 var path = require('path');
-//var sourcemaps = require('gulp-sourcemaps');
-//var stream = require('stream');
+var merge = require('merge');
 require('mocha');
 
 var createFile = function (filepath, contents) {
@@ -23,8 +21,6 @@ describe('gulp-react-templates', function () {
     describe('rt()', function () {
         before(function () {
             this.testData = function (expected, newPath, done) {
-                console.log('' + expected + ' ' + newPath);
-
                 var newPaths = [newPath],
                     expectedSourceMap;
 
@@ -79,7 +75,6 @@ describe('gulp-react-templates', function () {
 
             rt({bare: true})
                 .on('error', function (err) {
-                    //console.log('' + err);
                     err.message.should.equal('Document should have no more than a single root element');
                     done();
                 })
@@ -93,7 +88,8 @@ describe('gulp-react-templates', function () {
             var filepath = path.resolve(__dirname, '../fixtures/b.rt');
             var contents = new Buffer('<div>Hello</div>');
             var opts = {modules: 'none'};
-            var expected = reactTemplates.convertTemplateToReact(String(contents), opts);
+            var expected = reactTemplates.convertTemplateToReact(String(contents),
+                merge(opts, {name:'bRT'}));
 
             rt(opts)
                 .on('error', done)


### PR DESCRIPTION
fixed #2 
I use some code from original [react-templates](https://github.com/wix/react-templates) project. 
Error occurs because if `modules` is `none` react-templates need to create variable name for template. But `convertTemplateToReact` don't do it.
