### PR TITLE
Lock react-templates version <=0.1.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "gulp-util": "^3.0.0",
     "merge": "^1.2.0",
-    "react-templates": "^0.1.8",
+    "react-templates": "<=0.1.15",
     "through2": "^0.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Since 0.1.16 `convertTemplateToReact` takes 3 arguments instead of 2, so it doesn't pass options.
